### PR TITLE
(#5) Add feature generate insert/delete edge statements

### DIFF
--- a/const.go
+++ b/const.go
@@ -13,10 +13,3 @@ const (
 	ErrorTagNotFound  = "TagNotFound: Tag not existed!"
 	ErrorEdgeNotFound = "EdgeNotFound: Edge not existed!"
 )
-
-// Go tags representing Nebula related customizations
-const (
-	VID_GO_TAG               = "nebula_vid"
-	NEBULA_FIELD_GO_TAG      = "nebula_field"
-	NEBULA_FIELD_TYPE_GO_TAG = "nebula_field_type"
-)

--- a/statement/edge_delete_statement.go
+++ b/statement/edge_delete_statement.go
@@ -1,0 +1,33 @@
+package statement
+
+import (
+	"fmt"
+	"strings"
+)
+
+type DeleteEdgeStatement[TVidType VidType] struct {
+	SourceVid TVidType
+	TargetVid TVidType
+	Rank      int
+	EdgeType  string
+}
+
+// GenerateDeleteEdgeStatement takes a struct DeleteEdgeStatement and generates the corresponding
+// to DELETE EDGE scripts
+func GenerateDeleteEdgeStatement[TVidType VidType](statement DeleteEdgeStatement[TVidType]) (string, error) {
+	var sb strings.Builder
+
+	sourceVidValue, err := encodeVidFieldValueAsStr(statement.SourceVid)
+	if err != nil {
+		return "", err
+	}
+
+	targetVidValue, err := encodeVidFieldValueAsStr(statement.TargetVid)
+	if err != nil {
+		return "", err
+	}
+
+	sb.WriteString(fmt.Sprintf(`DELETE EDGE %s %v->%v@%d;`, statement.EdgeType, sourceVidValue, targetVidValue, statement.Rank))
+
+	return sb.String(), nil
+}

--- a/statement/edge_delete_statement_test.go
+++ b/statement/edge_delete_statement_test.go
@@ -1,0 +1,56 @@
+package statement
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGenerateDeleteEdgeStatementWhereVidStrings(t *testing.T) {
+	testCases := GetTestCasesForGenerateDeleteEdgeStatementWhereVidString()
+	for _, testcase := range testCases {
+		actual, err := GenerateDeleteEdgeStatement(testcase.Given)
+
+		if err != nil {
+			if !testcase.IsErrExpected {
+				t.Errorf("For %s, expected no error, got %v", testcase.Description, err)
+			}
+			continue
+		}
+
+		if !reflect.DeepEqual(actual, testcase.Expected) {
+			t.Errorf("For Case: %s "+
+				"\n Given: %+v "+
+				"\n Expected: %s, len: %d"+
+				"\n Got: %s, len: %d",
+				testcase.Description,
+				testcase.Given,
+				testcase.Expected, len(testcase.Expected),
+				actual, len(actual))
+		}
+	}
+}
+
+func TestGenerateDeleteEdgeStatementWhereVidInt64(t *testing.T) {
+	testCases := GetTestCasesForGenerateDeleteEdgeStatementWhereVidInt64()
+	for _, testcase := range testCases {
+		actual, err := GenerateDeleteEdgeStatement(testcase.Given)
+
+		if err != nil {
+			if !testcase.IsErrExpected {
+				t.Errorf("For %s, expected no error, got %v", testcase.Description, err)
+			}
+			continue
+		}
+
+		if !reflect.DeepEqual(actual, testcase.Expected) {
+			t.Errorf("For Case: %s "+
+				"\n Given: %+v "+
+				"\n Expected: %s, len: %d"+
+				"\n Got: %s, len: %d",
+				testcase.Description,
+				testcase.Given,
+				testcase.Expected, len(testcase.Expected),
+				actual, len(actual))
+		}
+	}
+}

--- a/statement/edge_insert_statement.go
+++ b/statement/edge_insert_statement.go
@@ -1,0 +1,139 @@
+package statement
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type InsertEdgeStatement[TVidType VidType] struct {
+	SourceVid   TVidType
+	TargetVid   TVidType
+	Properties  map[string]interface{}
+	Rank        int
+	EdgeType    string
+	IfNotExists bool
+}
+
+type InsertEdgeStatementOption[TVidType VidType] func(*InsertEdgeStatement[TVidType])
+
+// NewInsertEdgeStatement creates a new InsertEdgeStatement with the given source
+// vertex ID, target vertex ID, and edge type. It also allows for additional configuration
+// through a variadic list of options. The function initializes the properties map
+// and sets the IfNotExists flag to false by default. It applies each provided option
+// to the statement before returning it.
+//
+// Parameters:
+//   - sourceVid: The ID of the source vertex.
+//   - targetVid: The ID of the target vertex.
+//   - edgeType: The type of the edge.
+//   - options: A variadic list of functions that can modify the InsertEdgeStatement.
+//
+// Returns:
+//
+//	An initialized InsertEdgeStatement configured with the provided parameters and options.
+func NewInsertEdgeStatement[TVidType VidType](sourceVid, targetVid TVidType, edgeType string, options ...InsertEdgeStatementOption[TVidType]) InsertEdgeStatement[TVidType] {
+	statement := InsertEdgeStatement[TVidType]{
+		SourceVid:   sourceVid,
+		TargetVid:   targetVid,
+		EdgeType:    edgeType,
+		Properties:  make(map[string]interface{}),
+		IfNotExists: false,
+	}
+
+	// Apply all the functional options to configure the statement.
+	for _, opt := range options {
+		opt(&statement)
+	}
+
+	return statement
+}
+
+// WithRank sets the rank of the InsertEdgeStatement to the provided value.
+func WithRank[TVidType VidType](rank int) func(*InsertEdgeStatement[TVidType]) {
+	return func(stmt *InsertEdgeStatement[TVidType]) {
+		stmt.Rank = rank
+	}
+}
+
+// WithProperties sets the properties map of the InsertEdgeStatement to the provided map.
+func WithProperties[TVidType VidType](properties map[string]interface{}) func(*InsertEdgeStatement[TVidType]) {
+	return func(stmt *InsertEdgeStatement[TVidType]) {
+		stmt.Properties = properties
+	}
+}
+
+// WithIfNotExists sets the IfNotExists flag of the InsertEdgeStatement to the provided value.
+func WithIfNotExists[TVidType VidType](ifNotExists bool) func(*InsertEdgeStatement[TVidType]) {
+	return func(stmt *InsertEdgeStatement[TVidType]) {
+		stmt.IfNotExists = ifNotExists
+	}
+}
+
+// GenerateInsertEdgeStatement generates a string representation of the InsertEdgeStatement.
+// The function constructs the INSERT EDGE statement with the provided source and target vertex IDs,
+// edge type, rank, properties, and IfNotExists flag. It encodes the vertex IDs and properties
+// into the appropriate format and returns the resulting string.
+func GenerateInsertEdgeStatement[TVidType VidType](statement InsertEdgeStatement[TVidType]) (string, error) {
+	var sb strings.Builder
+
+	if statement.IfNotExists {
+		sb.WriteString(`INSERT EDGE IF NOT EXISTS `)
+	} else {
+		sb.WriteString(`INSERT EDGE `)
+	}
+
+	sb.WriteString(fmt.Sprintf(`%s`, statement.EdgeType))
+
+	sortedProperties := make([]string, 0, len(statement.Properties))
+	for k, _ := range statement.Properties {
+		sortedProperties = append(sortedProperties, k)
+	}
+	sort.Strings(sortedProperties)
+
+	if statement.Properties == nil || len(statement.Properties) == 0 {
+		sb.WriteString(` () `)
+	} else {
+		sb.WriteString(` (`)
+		for i, key := range sortedProperties {
+			if i > 0 {
+				sb.WriteString(`,`)
+			}
+			sb.WriteString(fmt.Sprintf(`%s`, key))
+		}
+		sb.WriteString(`) `)
+	}
+
+	sourceVidValue, err := encodeVidFieldValueAsStr(statement.SourceVid)
+	if err != nil {
+		return "", err
+	}
+
+	targetVidValue, err := encodeVidFieldValueAsStr(statement.TargetVid)
+	if err != nil {
+		return "", err
+	}
+
+	sb.WriteString(fmt.Sprintf(`VALUES %s->%s@%d:`, sourceVidValue, targetVidValue, statement.Rank))
+
+	if statement.Properties == nil || len(statement.Properties) == 0 {
+		sb.WriteString(`()`)
+	} else {
+		sb.WriteString(`(`)
+		for i, key := range sortedProperties {
+			if i > 0 {
+				sb.WriteString(`,`)
+			}
+			encodedVal, err := encodeNebulaFieldValue(statement.Properties[key])
+			if err != nil {
+				return "", err
+			}
+			sb.WriteString(fmt.Sprintf(`%v`, encodedVal))
+		}
+		sb.WriteString(`)`)
+	}
+
+	sb.WriteString(`;`)
+
+	return sb.String(), nil
+}

--- a/statement/edge_insert_statement_test.go
+++ b/statement/edge_insert_statement_test.go
@@ -1,0 +1,56 @@
+package statement
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGenerateInsertEdgeStatementWhereVidStrings(t *testing.T) {
+	testCases := GetTestCasesForGenerateInsertEdgeStatementWhereVidString()
+	for _, testcase := range testCases {
+		actual, err := GenerateInsertEdgeStatement(testcase.Given)
+
+		if err != nil {
+			if !testcase.IsErrExpected {
+				t.Errorf("For %s, expected no error, got %v", testcase.Description, err)
+			}
+			continue
+		}
+
+		if !reflect.DeepEqual(actual, testcase.Expected) {
+			t.Errorf("For Case: %s "+
+				"\n Given: %+v "+
+				"\n Expected: %s, len: %d"+
+				"\n Got: %s, len: %d",
+				testcase.Description,
+				testcase.Given,
+				testcase.Expected, len(testcase.Expected),
+				actual, len(actual))
+		}
+	}
+}
+
+func TestGenerateInsertEdgeStatementWhereVidInt64(t *testing.T) {
+	testCases := GetTestCasesForGenerateInsertEdgeStatementWhereVidInt64()
+	for _, testcase := range testCases {
+		actual, err := GenerateInsertEdgeStatement(testcase.Given)
+
+		if err != nil {
+			if !testcase.IsErrExpected {
+				t.Errorf("For %s, expected no error, got %v", testcase.Description, err)
+			}
+			continue
+		}
+
+		if !reflect.DeepEqual(actual, testcase.Expected) {
+			t.Errorf("For Case: %s "+
+				"\n Given: %+v "+
+				"\n Expected: %s, len: %d"+
+				"\n Got: %s, len: %d",
+				testcase.Description,
+				testcase.Given,
+				testcase.Expected, len(testcase.Expected),
+				actual, len(actual))
+		}
+	}
+}

--- a/statement/edge_testcases.go
+++ b/statement/edge_testcases.go
@@ -1,0 +1,107 @@
+package statement
+
+type TestCaseGenerateInsertEdgeStatement[TVidType string | int64] struct {
+	Description   string
+	Given         InsertEdgeStatement[TVidType]
+	Expected      string
+	IsErrExpected bool
+}
+
+type TestCaseGenerateDeleteEdgeStatement[TVidType string | int64] struct {
+	Description   string
+	Given         DeleteEdgeStatement[TVidType]
+	Expected      string
+	IsErrExpected bool
+}
+
+func GetTestCasesForGenerateInsertEdgeStatementWhereVidString() []TestCaseGenerateInsertEdgeStatement[string] {
+	return []TestCaseGenerateInsertEdgeStatement[string]{
+		{
+			Description:   "A simple insert edge statement without properties and with default settings",
+			Given:         NewInsertEdgeStatement[string]("John", "Alive", "Friend"),
+			Expected:      `INSERT EDGE Friend () VALUES "John"->"Alive"@0:();`,
+			IsErrExpected: false,
+		},
+		{
+			Description: "A simple insert edge statement without properties and with default settings",
+			Given: NewInsertEdgeStatement[string]("John", "Alive", "Friend",
+				WithProperties[string](map[string]interface{}{"key1": "strval1", "key2": 121}),
+				WithIfNotExists[string](true),
+				WithRank[string](100)),
+			Expected:      `INSERT EDGE IF NOT EXISTS Friend (key1,key2) VALUES "John"->"Alive"@100:("strval1",121);`,
+			IsErrExpected: false,
+		},
+	}
+}
+
+func GetTestCasesForGenerateInsertEdgeStatementWhereVidInt64() []TestCaseGenerateInsertEdgeStatement[int64] {
+	return []TestCaseGenerateInsertEdgeStatement[int64]{
+		{
+			Description:   "A simple insert edge statement without properties and with default settings",
+			Given:         NewInsertEdgeStatement[int64](100, 200, "Friend"),
+			Expected:      `INSERT EDGE Friend () VALUES 100->200@0:();`,
+			IsErrExpected: false,
+		},
+		{
+			Description: "A simple insert edge statement without properties and with default settings",
+			Given: NewInsertEdgeStatement[int64](100, 200, "Friend",
+				WithProperties[int64](map[string]interface{}{"key1": "strval1", "key2": 121}),
+				WithIfNotExists[int64](true),
+				WithRank[int64](100)),
+			Expected:      `INSERT EDGE IF NOT EXISTS Friend (key1,key2) VALUES 100->200@100:("strval1",121);`,
+			IsErrExpected: false,
+		},
+	}
+}
+
+func GetTestCasesForGenerateDeleteEdgeStatementWhereVidString() []TestCaseGenerateDeleteEdgeStatement[string] {
+	return []TestCaseGenerateDeleteEdgeStatement[string]{
+		{
+			Description: "A simple insert edge statement without properties and with default settings",
+			Given: DeleteEdgeStatement[string]{
+				SourceVid: "John",
+				TargetVid: "Alive",
+				EdgeType:  "Friend",
+			},
+			Expected:      `DELETE EDGE Friend "John"->"Alive"@0;`,
+			IsErrExpected: false,
+		},
+		{
+			Description: "A simple insert edge statement without properties and with default settings",
+			Given: DeleteEdgeStatement[string]{
+				SourceVid: "John",
+				TargetVid: "Alive",
+				EdgeType:  "Friend",
+				Rank:      99,
+			},
+			Expected:      `DELETE EDGE Friend "John"->"Alive"@99;`,
+			IsErrExpected: false,
+		},
+	}
+}
+
+func GetTestCasesForGenerateDeleteEdgeStatementWhereVidInt64() []TestCaseGenerateDeleteEdgeStatement[int64] {
+	return []TestCaseGenerateDeleteEdgeStatement[int64]{
+		{
+			Description: "A simple insert edge statement without properties and with default settings",
+			Given: DeleteEdgeStatement[int64]{
+				SourceVid: 100,
+				TargetVid: 200,
+				EdgeType:  "Friend",
+			},
+			Expected:      `DELETE EDGE Friend 100->200@0;`,
+			IsErrExpected: false,
+		},
+		{
+			Description: "A simple insert edge statement without properties and with default settings",
+			Given: DeleteEdgeStatement[int64]{
+				SourceVid: 100,
+				TargetVid: 200,
+				EdgeType:  "Friend",
+				Rank:      99,
+			},
+			Expected:      `DELETE EDGE Friend 100->200@99;`,
+			IsErrExpected: false,
+		},
+	}
+}

--- a/statement/shared.go
+++ b/statement/shared.go
@@ -1,0 +1,41 @@
+package statement
+
+import "fmt"
+
+type VidType interface {
+	string | int64
+}
+
+// Go tags representing Nebula related customizations
+const (
+	VID_GO_TAG               = "nebula_vid"
+	NEBULA_FIELD_GO_TAG      = "nebula_field"
+	NEBULA_FIELD_TYPE_GO_TAG = "nebula_field_type"
+)
+
+func encodeVidFieldValueAsStr(vidValue any) (string, error) {
+	switch v := vidValue.(type) {
+	case string:
+		return fmt.Sprintf(`"%s"`, v), nil
+	case int64:
+		return fmt.Sprintf(`%v`, v), nil
+	default:
+		return "", fmt.Errorf("unsupported vid type: %T", v)
+	}
+}
+
+func encodeNebulaFieldValue(fieldValue any) (string, error) {
+	switch v := fieldValue.(type) {
+	case string:
+		return fmt.Sprintf(`"%s"`, v), nil
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf(`%v`, v), nil
+	case float32, float64:
+		return fmt.Sprintf(`%v`, v), nil
+	case bool:
+		return fmt.Sprintf(`%v`, v), nil
+	default:
+		return "", fmt.Errorf("unsupported vid type: %T", v)
+	}
+}

--- a/statement/vertex_delete_statement.go
+++ b/statement/vertex_delete_statement.go
@@ -1,0 +1,79 @@
+package statement
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// DeleteVertexStatement is a struct that stores the vertex IDs and whether to delete the edges associated to vertices
+type DeleteVertexStatement[TVidType VidType] struct {
+	VertexIds []TVidType
+	WithEdge  bool
+}
+
+// GenerateDeleteVertexStatement takes a slice of struct vertices and generates the corresponding
+// to DELETE VERTEX scripts
+func GenerateDeleteVertexStatement[TVidType VidType](statement DeleteVertexStatement[TVidType]) (string, error) {
+	if len(statement.VertexIds) == 0 {
+		return "", fmt.Errorf("empty VertexIds provided ")
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString("DELETE VERTEX ")
+
+	// DELETE VERTEX <vid> [, <vid> ...] [WITH EDGE];
+	var vidsJoined string
+	for i, item := range statement.VertexIds {
+		if i > 0 {
+			vidsJoined += ", "
+		}
+
+		switch reflect.TypeOf(item).Kind() {
+		case reflect.String:
+			vidsJoined += fmt.Sprintf(`"%v"`, item)
+		case reflect.Int64:
+			vidsJoined += fmt.Sprintf(`%v`, item)
+		default:
+			return "", fmt.Errorf("unsupported type")
+		}
+	}
+
+	sb.WriteString(vidsJoined)
+
+	if statement.WithEdge {
+		sb.WriteString(" WITH EDGE;")
+	} else {
+		sb.WriteString(";")
+	}
+
+	return sb.String(), nil
+}
+
+// GenerateBatchedDeleteVertexStatements takes a slice of struct vertices and generates the corresponding
+// to DELETE VERTEX scripts separated by semicolons. The function takes an additional parameter batchSize
+// which specifies the number of vertices to process in each batch.
+func GenerateBatchedDeleteVertexStatements[TVidType VidType](statement DeleteVertexStatement[TVidType], batchSize int) ([]string, error) {
+	scripts := make([]string, 0)
+	for i := 0; i < len(statement.VertexIds); i = i + batchSize {
+		st := i
+		end := i + batchSize
+		if end > len(statement.VertexIds) {
+			end = len(statement.VertexIds)
+		}
+
+		newStatement := DeleteVertexStatement[TVidType]{
+			VertexIds: statement.VertexIds[st:end],
+			WithEdge:  statement.WithEdge,
+		}
+
+		script, err := GenerateDeleteVertexStatement(newStatement)
+		if err != nil {
+			return nil, err
+		}
+		scripts = append(scripts, script)
+	}
+
+	return scripts, nil
+}

--- a/statement/vertex_delete_statement_test.go
+++ b/statement/vertex_delete_statement_test.go
@@ -5,62 +5,6 @@ import (
 	"testing"
 )
 
-func TestGenerateInsertVertexStatement(t *testing.T) {
-	testCases := GetTestCasesForGenerateInsertVertexStatement()
-	for _, testcase := range testCases {
-		actual, err := GenerateInsertVertexStatement(testcase.GivenVerticesArray)
-
-		if err != nil {
-			if !testcase.IsErrExpected {
-				t.Errorf("For %s, expected no error, got %v", testcase.Description, err)
-			}
-			continue
-		}
-
-		if !reflect.DeepEqual(actual, testcase.Expected) {
-			t.Errorf("For Case: %s "+
-				"\n Given: %+q, arr len: %d "+
-				"\n Expected: %s, len: %d"+
-				"\n Got: %s, len: %d",
-				testcase.Description,
-				testcase.GivenVerticesArray, len(testcase.GivenVerticesArray),
-				testcase.Expected, len(testcase.Expected),
-				actual, len(actual))
-		}
-	}
-}
-
-func TestGenerateBatchedInsertVertexStatements(t *testing.T) {
-	testCases := GetTestCasesForGenerateBatchedInsertVertexStatements()
-	for _, testcase := range testCases {
-		actual, err := GenerateBatchedInsertVertexStatements(testcase.GivenVerticesArray, testcase.GivenBatchSize)
-
-		if err != nil {
-			if !testcase.IsErrExpected {
-				t.Errorf("For %s, expected no error, got %v", testcase.Description, err)
-			}
-			continue
-		}
-
-		if len(actual) != len(testcase.Expected) {
-			t.Errorf("For %s, expected %d insert scripts, got %d", testcase.Description, len(testcase.Expected), len(actual))
-		}
-
-		for i := 0; i < len(actual); i++ {
-			if !reflect.DeepEqual(actual[i], testcase.Expected[i]) {
-				t.Errorf("For Case: %s "+
-					"\n Given: %v, batchSize: %d "+
-					"\n Expected: %s, len: %d"+
-					"\n Got: %s, len: %d",
-					testcase.Description,
-					testcase.GivenVerticesArray, testcase.GivenBatchSize,
-					testcase.Expected, len(testcase.Expected),
-					actual, len(actual))
-			}
-		}
-	}
-}
-
 func TestGenerateGenerateDeleteVertexStatementWhereVidString(t *testing.T) {
 	testCases := GetTestCasesForDeleteVertexStatementWhereVidString()
 	for _, testcase := range testCases {

--- a/statement/vertex_insert_statement_test.go
+++ b/statement/vertex_insert_statement_test.go
@@ -1,0 +1,62 @@
+package statement
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGenerateInsertVertexStatement(t *testing.T) {
+	testCases := GetTestCasesForGenerateInsertVertexStatement()
+	for _, testcase := range testCases {
+		actual, err := GenerateInsertVertexStatement(testcase.GivenVerticesArray)
+
+		if err != nil {
+			if !testcase.IsErrExpected {
+				t.Errorf("For %s, expected no error, got %v", testcase.Description, err)
+			}
+			continue
+		}
+
+		if !reflect.DeepEqual(actual, testcase.Expected) {
+			t.Errorf("For Case: %s "+
+				"\n Given: %+q, arr len: %d "+
+				"\n Expected: %s, len: %d"+
+				"\n Got: %s, len: %d",
+				testcase.Description,
+				testcase.GivenVerticesArray, len(testcase.GivenVerticesArray),
+				testcase.Expected, len(testcase.Expected),
+				actual, len(actual))
+		}
+	}
+}
+
+func TestGenerateBatchedInsertVertexStatements(t *testing.T) {
+	testCases := GetTestCasesForGenerateBatchedInsertVertexStatements()
+	for _, testcase := range testCases {
+		actual, err := GenerateBatchedInsertVertexStatements(testcase.GivenVerticesArray, testcase.GivenBatchSize)
+
+		if err != nil {
+			if !testcase.IsErrExpected {
+				t.Errorf("For %s, expected no error, got %v", testcase.Description, err)
+			}
+			continue
+		}
+
+		if len(actual) != len(testcase.Expected) {
+			t.Errorf("For %s, expected %d insert scripts, got %d", testcase.Description, len(testcase.Expected), len(actual))
+		}
+
+		for i := 0; i < len(actual); i++ {
+			if !reflect.DeepEqual(actual[i], testcase.Expected[i]) {
+				t.Errorf("For Case: %s "+
+					"\n Given: %v, batchSize: %d "+
+					"\n Expected: %s, len: %d"+
+					"\n Got: %s, len: %d",
+					testcase.Description,
+					testcase.GivenVerticesArray, testcase.GivenBatchSize,
+					testcase.Expected, len(testcase.Expected),
+					actual, len(actual))
+			}
+		}
+	}
+}


### PR DESCRIPTION
The PR includes the changes for #5 

Additonal changes:
- reorganized statement generation per type(_vertex, edge_) and _operation_ into separate files(_vertex_insert.go, vertex_delete.go_), to make it more readable and maintainable
- applied _Options pattern_ for generation of insert statements of _Edge_ due to having multiple optional params, making it more maintainable.
- add unit tests with testcases to make it more reliable during library development to make sure its working properly after changes 